### PR TITLE
Deprecate ResizeBuffer

### DIFF
--- a/component.json
+++ b/component.json
@@ -12,8 +12,7 @@
     "https://raw.githubusercontent.com"
   ],
   "scripts": [
-    "index.js",
-    "components/Resize-node.coffee"
+    "index.js"
   ],
   "json": [
     "component.json"

--- a/components/Resize-node.coffee
+++ b/components/Resize-node.coffee
@@ -1,6 +1,6 @@
 noflo = require 'noflo'
 sharp = require 'sharp'
-Canvas = require('noflo-canvas').canvas
+path = require 'path'
 
 # @runtime noflo-nodejs
 # @name Resize
@@ -9,11 +9,11 @@ exports.getComponent = ->
   c = new noflo.Component
 
   c.icon = 'expand'
-  c.description = 'Resize a given image to the new dimension'
+  c.description = 'Resize a given image file to the new dimension'
 
-  c.inPorts.add 'path',
-    datatype: 'string'
-    description: 'Path to image to be resized'
+  c.inPorts.add 'in',
+    datatype: 'all'
+    description: 'Path to image file or image buffer to be resized'
   c.inPorts.add 'width',
     datatype: 'integer'
     description: 'New width'
@@ -22,48 +22,66 @@ exports.getComponent = ->
     datatype: 'integer'
     description: 'New height'
     required: false
-  c.outPorts.add 'canvas',
-    datatype: 'string'
+
+  c.outPorts.add 'out',
+    datatype: 'all'
+    description: 'Resized buffer'
+  c.outPorts.add 'factor',
+    datatype: 'number'
+    description: 'Original over resized dimensions factor'
+    required: false
   c.outPorts.add 'error',
     datatype: 'object'
     required: false
 
   noflo.helpers.WirePattern c,
-    in: ['path']
+    in: ['in']
     params: ['width', 'height']
-    out: ['canvas']
+    out: ['out', 'factor']
     async: true
     forwardGroups: true
   , (payload, groups, out, callback) ->
+    if (not Buffer.isBuffer payload) and (typeof payload isnt 'string')
+      return callback Error 'Input is not a valid buffer nor image path'
     width = c.params.width
     height = c.params.height
     if not width? and not height?
       width = 256
-    path = payload
     try
-      inputBuffer = sharp path
+      inputBuffer = sharp payload
       inputBuffer.metadata (err, metadata) ->
         if err
           return callback err
-        inputBuffer
-        .resize width, height
-        .withMetadata()
-        .withoutEnlargement()
-        .toFormat 'png'
-        .toBuffer (err, outputBuffer, info) ->
-          if err
-            return callback err
-          # Create image with buffer as src
-          image = new Canvas.Image
-          image.src = outputBuffer
-          # Create a host canvas and draw on it
-          canvas = new Canvas(info.width, info.height)
-          ctx = canvas.getContext '2d'
-          ctx.drawImage image, 0, 0, info.width, info.height
-          canvas.originalWidth = metadata.width
-          canvas.originalHeight = metadata.height
-          out.send canvas
-          do callback
+        # Try to preserve the same format, if there's EXIF
+        if metadata.exif?
+          inputBuffer
+          .resize width, height
+          .withMetadata()
+          .withoutEnlargement()
+          .toBuffer (err, outputBuffer, info) ->
+            if err
+              return callback err
+            originalWidth = metadata.width
+            resizedWidth = info.width
+            factor = originalWidth / resizedWidth
+            out.out.send outputBuffer
+            out.factor.send factor
+            do callback
+        else
+          inputBuffer
+          .resize width, height
+          .withMetadata()
+          .withoutEnlargement()
+          .toFormat 'png'
+          .toBuffer (err, outputBuffer, info) ->
+            if err
+              return callback err
+            originalWidth = metadata.width
+            resizedWidth = info.width
+            factor = originalWidth / resizedWidth
+            out.out.send outputBuffer
+            out.factor.send factor
+            do callback
     catch err
       return callback err
 

--- a/components/Resize-node.coffee
+++ b/components/Resize-node.coffee
@@ -12,7 +12,7 @@ exports.getComponent = ->
   c.description = 'Resize a given image file to the new dimension'
   c.defaultDimension = 1024
 
-  c.inPorts.add 'in',
+  c.inPorts.add 'path',
     datatype: 'all'
     description: 'Path to image file or image buffer to be resized'
   c.inPorts.add 'width',
@@ -48,7 +48,7 @@ exports.getComponent = ->
     required: false
 
   noflo.helpers.WirePattern c,
-    in: ['in']
+    in: ['path']
     params: ['width', 'height']
     out: ['out', 'factor', 'original', 'resized', 'metadata']
     async: true

--- a/components/Resize-node.coffee
+++ b/components/Resize-node.coffee
@@ -70,60 +70,33 @@ exports.getComponent = ->
             width = c.defaultDimension
           else
             height = c.defaultDimension
-        # Try to preserve the same format, if there's EXIF
-        if metadata.exif?
-          inputBuffer
-          .resize width, height
-          .withMetadata()
-          .withoutEnlargement()
-          .toBuffer (err, outputBuffer, info) ->
-            if err
-              return callback err
-            if width
-              originalWidth = metadata.width
-              resizedWidth = info.width
-              factor = originalWidth / resizedWidth
-            else
-              originalHeight = metadata.height
-              resizedHeight = info.height
-              factor = originalHeight / resizedHeight
-            out.out.send outputBuffer
-            out.factor.send factor
-            out.original.send
-              width: metadata.width
-              height: metadata.height
-            out.resized.send
-              width: info.width
-              height: info.height
-            out.metadata.send metadata
-            do callback
-        else
-          inputBuffer
-          .resize width, height
-          .withMetadata()
-          .withoutEnlargement()
-          .toFormat 'png'
-          .toBuffer (err, outputBuffer, info) ->
-            if err
-              return callback err
-            if width
-              originalWidth = metadata.width
-              resizedWidth = info.width
-              factor = originalWidth / resizedWidth
-            else
-              originalHeight = metadata.height
-              resizedHeight = info.height
-              factor = originalHeight / resizedHeight
-            out.out.send outputBuffer
-            out.factor.send factor
-            out.original.send
-              width: metadata.width
-              height: metadata.height
-            out.resized.send
-              width: info.width
-              height: info.height
-            out.metadata.send metadata
-            do callback
+        format = if metadata.exif? then 'jpeg' else 'png'
+        inputBuffer
+        .resize width, height
+        .withMetadata()
+        .withoutEnlargement()
+        .toFormat format
+        .toBuffer (err, outputBuffer, info) ->
+          if err
+            return callback err
+          if width
+            originalWidth = metadata.width
+            resizedWidth = info.width
+            factor = originalWidth / resizedWidth
+          else
+            originalHeight = metadata.height
+            resizedHeight = info.height
+            factor = originalHeight / resizedHeight
+          out.out.send outputBuffer
+          out.factor.send factor
+          out.original.send
+            width: metadata.width
+            height: metadata.height
+          out.resized.send
+            width: info.width
+            height: info.height
+          out.metadata.send metadata
+          do callback
     catch err
       return callback err
 

--- a/components/Resize-node.coffee
+++ b/components/Resize-node.coffee
@@ -30,6 +30,18 @@ exports.getComponent = ->
     datatype: 'number'
     description: 'Original over resized dimensions factor'
     required: false
+  c.outPorts.add 'original',
+    datatype: 'object'
+    description: 'Original dimension'
+    required: false
+  c.outPorts.add 'resized',
+    datatype: 'object'
+    description: 'Resized dimension'
+    required: false
+  c.outPorts.add 'metadata',
+    datatype: 'object'
+    description: 'Extracted metadata while resizing'
+    required: false
   c.outPorts.add 'error',
     datatype: 'object'
     required: false
@@ -37,7 +49,7 @@ exports.getComponent = ->
   noflo.helpers.WirePattern c,
     in: ['in']
     params: ['width', 'height']
-    out: ['out', 'factor']
+    out: ['out', 'factor', 'original', 'resized', 'metadata']
     async: true
     forwardGroups: true
   , (payload, groups, out, callback) ->
@@ -66,6 +78,13 @@ exports.getComponent = ->
             factor = originalWidth / resizedWidth
             out.out.send outputBuffer
             out.factor.send factor
+            out.original.send
+              width: metadata.width
+              height: metadata.height
+            out.resized.send
+              width: info.width
+              height: info.height
+            out.metadata.send metadata
             do callback
         else
           inputBuffer
@@ -81,6 +100,13 @@ exports.getComponent = ->
             factor = originalWidth / resizedWidth
             out.out.send outputBuffer
             out.factor.send factor
+            out.original.send
+              width: metadata.width
+              height: metadata.height
+            out.resized.send
+              width: info.width
+              height: info.height
+            out.metadata.send metadata
             do callback
     catch err
       return callback err

--- a/components/Resize-node.coffee
+++ b/components/Resize-node.coffee
@@ -27,18 +27,6 @@ exports.getComponent = ->
   c.outPorts.add 'out',
     datatype: 'all'
     description: 'Resized buffer'
-  c.outPorts.add 'factor',
-    datatype: 'number'
-    description: 'Original over resized dimensions factor'
-    required: false
-  c.outPorts.add 'original',
-    datatype: 'object'
-    description: 'Original dimension'
-    required: false
-  c.outPorts.add 'resized',
-    datatype: 'object'
-    description: 'Resized dimension'
-    required: false
   c.outPorts.add 'metadata',
     datatype: 'object'
     description: 'Extracted metadata while resizing'
@@ -50,7 +38,7 @@ exports.getComponent = ->
   noflo.helpers.WirePattern c,
     in: ['path']
     params: ['width', 'height']
-    out: ['out', 'factor', 'original', 'resized', 'metadata']
+    out: ['out', 'metadata']
     async: true
     forwardGroups: true
   , (payload, groups, out, callback) ->
@@ -87,14 +75,10 @@ exports.getComponent = ->
             originalHeight = metadata.height
             resizedHeight = info.height
             factor = originalHeight / resizedHeight
+          metadata.resizedWidth = info.width
+          metadata.resizedHeight = info.height
+          metadata.factor = factor
           out.out.send outputBuffer
-          out.factor.send factor
-          out.original.send
-            width: metadata.width
-            height: metadata.height
-          out.resized.send
-            width: info.width
-            height: info.height
           out.metadata.send metadata
           do callback
     catch err

--- a/components/ResizeBuffer-node.coffee
+++ b/components/ResizeBuffer-node.coffee
@@ -39,6 +39,7 @@ exports.getComponent = ->
     async: true
     forwardGroups: true
   , (payload, groups, out, callback) ->
+    console.log 'Warning: This component is deprecated, use Resize instead'
     width = c.params.width
     height = c.params.height
     try
@@ -54,45 +55,26 @@ exports.getComponent = ->
           else
             height = c.defaultDimension
         # Try to preserve the same format, if there's EXIF
-        if metadata.exif?
-          inputBuffer
-          .resize width, height
-          .withMetadata()
-          .withoutEnlargement()
-          .toBuffer (err, outputBuffer, info) ->
-            if err
-              return callback err
-            if width
-              originalWidth = metadata.width
-              resizedWidth = info.width
-              factor = originalWidth / resizedWidth
-            else
-              originalHeight = metadata.height
-              resizedHeight = info.height
-              factor = originalHeight / resizedHeight
-            out.buffer.send outputBuffer
-            out.factor.send factor
-            do callback
-        else
-          inputBuffer
-          .resize width, height
-          .withMetadata()
-          .withoutEnlargement()
-          .toFormat('png')
-          .toBuffer (err, outputBuffer, info) ->
-            if err
-              return callback err
-            if width
-              originalWidth = metadata.width
-              resizedWidth = info.width
-              factor = originalWidth / resizedWidth
-            else
-              originalHeight = metadata.height
-              resizedHeight = info.height
-              factor = originalHeight / resizedHeight
-            out.buffer.send outputBuffer
-            out.factor.send factor
-            do callback
+        format = if metadata.exif? then 'jpeg' else 'png'
+        inputBuffer
+        .resize width, height
+        .withMetadata()
+        .withoutEnlargement()
+        .toFormat format
+        .toBuffer (err, outputBuffer, info) ->
+          if err
+            return callback err
+          if width
+            originalWidth = metadata.width
+            resizedWidth = info.width
+            factor = originalWidth / resizedWidth
+          else
+            originalHeight = metadata.height
+            resizedHeight = info.height
+            factor = originalHeight / resizedHeight
+          out.buffer.send outputBuffer
+          out.factor.send factor
+          do callback
     catch err
       return callback err
 

--- a/spec/Resize.coffee
+++ b/spec/Resize.coffee
@@ -104,16 +104,14 @@ describe 'Resize component', ->
 
     it 'should resize it right to default dimension', (done) ->
       expected =
-        width: 256
-        height: 256
+        width: c.defaultDimension
       out.on 'data', (data) ->
         buffer = sharp data
         buffer.metadata (err, meta) ->
           chai.expect(meta.width).to.be.equal expected.width
-          chai.expect(meta.height).to.be.equal expected.height
           done()
 
-      testutils.getBuffer __dirname + '/fixtures/lenna.png', (buffer) ->
+      testutils.getBuffer __dirname + '/fixtures/foo.jpeg', (buffer) ->
         ins.send buffer
 
     it 'should not resize up (just down, without enlargement)', (done) ->
@@ -178,16 +176,14 @@ describe 'Resize component', ->
 
     it 'should resize it right to default dimension', (done) ->
       expected =
-        width: 256
-        height: 256
+        width: c.defaultDimension
       out.on 'data', (data) ->
         buffer = sharp data
         buffer.metadata (err, meta) ->
           chai.expect(meta.width).to.be.equal expected.width
-          chai.expect(meta.height).to.be.equal expected.height
           done()
 
-      ins.send __dirname + '/fixtures/lenna.png'
+      ins.send __dirname + '/fixtures/foo.jpeg'
 
     it 'should not resize up (just down, without enlargement)', (done) ->
       expected =
@@ -226,6 +222,46 @@ describe 'Resize component', ->
         chai.expect(data).to.be.eql err
         done()
       testutils.getBuffer __dirname + '/Resize.coffee', (buffer) ->
+        ins.send buffer
+
+  describe 'when passed a narrow image with default values', ->
+    it 'should resize to (? x default height)', (done) ->
+      original =
+        width: 736
+        height: 7337
+      expected =
+        height: c.defaultDimension
+      calculatedFactor = null
+      factor.on 'data', (data) ->
+        calculatedFactor = data
+      out.on 'data', (data) ->
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.height).to.be.equal expected.height
+          chai.expect(calculatedFactor).to.be.equal original.height / expected.height
+          done()
+
+      testutils.getBuffer __dirname + '/fixtures/narrow.jpg', (buffer) ->
+        ins.send buffer
+
+  describe 'when passed a wide image with default values', ->
+    it 'should resize to (default width x ?)', (done) ->
+      original =
+        width: 7337
+        height: 736
+      expected =
+        width: c.defaultDimension
+      calculatedFactor = null
+      factor.on 'data', (data) ->
+        calculatedFactor = data
+      out.on 'data', (data) ->
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.width
+          chai.expect(calculatedFactor).to.be.equal original.width / expected.width
+          done()
+
+      testutils.getBuffer __dirname + '/fixtures/wide.jpg', (buffer) ->
         ins.send buffer
 
   describe 'when passed a GIF buffer', ->

--- a/spec/Resize.coffee
+++ b/spec/Resize.coffee
@@ -14,6 +14,9 @@ describe 'Resize component', ->
   width = null
   height = null
   factor = null
+  original = null
+  resized = null
+  metadata = null
   error = null
   out = null
   beforeEach ->
@@ -22,12 +25,18 @@ describe 'Resize component', ->
     width = noflo.internalSocket.createSocket()
     height = noflo.internalSocket.createSocket()
     factor = noflo.internalSocket.createSocket()
+    original = noflo.internalSocket.createSocket()
+    resized = noflo.internalSocket.createSocket()
+    metadata = noflo.internalSocket.createSocket()
     error = noflo.internalSocket.createSocket()
     out = noflo.internalSocket.createSocket()
     c.inPorts.in.attach ins
     c.inPorts.width.attach width
     c.inPorts.height.attach height
     c.outPorts.factor.attach factor
+    c.outPorts.original.attach original
+    c.outPorts.resized.attach resized
+    c.outPorts.metadata.attach metadata
     c.outPorts.error.attach error
     c.outPorts.out.attach out
 
@@ -38,6 +47,9 @@ describe 'Resize component', ->
       chai.expect(c.inPorts.height).to.be.an 'object'
     it 'should have output ports', ->
       chai.expect(c.outPorts.factor).to.be.an 'object'
+      chai.expect(c.outPorts.original).to.be.an 'object'
+      chai.expect(c.outPorts.resized).to.be.an 'object'
+      chai.expect(c.outPorts.metadata).to.be.an 'object'
       chai.expect(c.outPorts.out).to.be.an 'object'
     it 'should have error port', ->
       chai.expect(c.outPorts.error).to.be.an 'object'

--- a/spec/Resize.coffee
+++ b/spec/Resize.coffee
@@ -30,7 +30,7 @@ describe 'Resize component', ->
     metadata = noflo.internalSocket.createSocket()
     error = noflo.internalSocket.createSocket()
     out = noflo.internalSocket.createSocket()
-    c.inPorts.in.attach ins
+    c.inPorts.path.attach ins
     c.inPorts.width.attach width
     c.inPorts.height.attach height
     c.outPorts.factor.attach factor
@@ -42,7 +42,7 @@ describe 'Resize component', ->
 
   describe 'when instantiated', ->
     it 'should have input ports', ->
-      chai.expect(c.inPorts.in).to.be.an 'object'
+      chai.expect(c.inPorts.path).to.be.an 'object'
       chai.expect(c.inPorts.width).to.be.an 'object'
       chai.expect(c.inPorts.height).to.be.an 'object'
     it 'should have output ports', ->

--- a/spec/Resize.coffee
+++ b/spec/Resize.coffee
@@ -3,6 +3,7 @@ unless noflo.isBrowser()
   chai = require 'chai' unless chai
   Resize = require '../components/Resize-node.coffee'
   testutils = require './testutils'
+  sharp = require 'sharp'
 else
   Resize = require 'noflo-sharp/components/Resize.js'
   testutils = require 'noflo-image/spec/testutils.js'
@@ -12,27 +13,36 @@ describe 'Resize component', ->
   ins = null
   width = null
   height = null
+  factor = null
+  error = null
   out = null
   beforeEach ->
     c = Resize.getComponent()
     ins = noflo.internalSocket.createSocket()
     width = noflo.internalSocket.createSocket()
     height = noflo.internalSocket.createSocket()
+    factor = noflo.internalSocket.createSocket()
+    error = noflo.internalSocket.createSocket()
     out = noflo.internalSocket.createSocket()
-    c.inPorts.path.attach ins
+    c.inPorts.in.attach ins
     c.inPorts.width.attach width
     c.inPorts.height.attach height
-    c.outPorts.canvas.attach out
+    c.outPorts.factor.attach factor
+    c.outPorts.error.attach error
+    c.outPorts.out.attach out
 
   describe 'when instantiated', ->
     it 'should have input ports', ->
-      chai.expect(c.inPorts.path).to.be.an 'object'
+      chai.expect(c.inPorts.in).to.be.an 'object'
       chai.expect(c.inPorts.width).to.be.an 'object'
       chai.expect(c.inPorts.height).to.be.an 'object'
-    it 'should have an output port', ->
-      chai.expect(c.outPorts.canvas).to.be.an 'object'
+    it 'should have output ports', ->
+      chai.expect(c.outPorts.factor).to.be.an 'object'
+      chai.expect(c.outPorts.out).to.be.an 'object'
+    it 'should have error port', ->
+      chai.expect(c.outPorts.error).to.be.an 'object'
 
-  describe 'when passed an image', ->
+  describe 'when passed an image buffer', ->
     original =
       width: 512
       height: 512
@@ -41,27 +51,102 @@ describe 'Resize component', ->
         width: 128
         height: 256
       out.on 'data', (data) ->
-        chai.expect(data).to.be.an 'object'
-        chai.expect(data.width).to.be.equal expected.width
-        chai.expect(data.height).to.be.equal expected.height
-        chai.expect(data.originalWidth).to.be.equal original.width
-        chai.expect(data.originalHeight).to.be.equal original.height
-        done()
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.width
+          chai.expect(meta.height).to.be.equal expected.height
+          done()
 
       width.send expected.width
       height.send expected.height
-      ins.send __dirname + '/fixtures/lenna.png'
+      testutils.getBuffer __dirname + '/fixtures/foo.jpeg', (buffer) ->
+        ins.send buffer
 
     it 'should resize it right when given just width', (done) ->
       expected =
         width: 128
       out.on 'data', (data) ->
-        chai.expect(data).to.be.an 'object'
-        chai.expect(data.width).to.be.equal expected.width
-        chai.expect(data.height).to.be.equal expected.width
-        chai.expect(data.originalWidth).to.be.equal original.width
-        chai.expect(data.originalHeight).to.be.equal original.height
-        done()
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.width
+          chai.expect(meta.height).to.be.equal expected.width
+          done()
+
+      width.send expected.width
+      testutils.getBuffer __dirname + '/fixtures/lenna.png', (buffer) ->
+        ins.send buffer
+
+    it 'should resize it right when given just height', (done) ->
+      expected =
+        height: 128
+      out.on 'data', (data) ->
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.height
+          chai.expect(meta.height).to.be.equal expected.height
+          done()
+
+      height.send expected.height
+      testutils.getBuffer __dirname + '/fixtures/lenna.png', (buffer) ->
+        ins.send buffer
+
+    it 'should resize it right to default dimension', (done) ->
+      expected =
+        width: 256
+        height: 256
+      out.on 'data', (data) ->
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.width
+          chai.expect(meta.height).to.be.equal expected.height
+          done()
+
+      testutils.getBuffer __dirname + '/fixtures/lenna.png', (buffer) ->
+        ins.send buffer
+
+    it 'should not resize up (just down, without enlargement)', (done) ->
+      expected =
+        width: 512
+        height: 512
+      out.on 'data', (data) ->
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.width
+          chai.expect(meta.height).to.be.equal expected.height
+          done()
+
+      width.send 1024
+      testutils.getBuffer __dirname + '/fixtures/lenna.png', (buffer) ->
+        ins.send buffer
+
+  describe 'when passed a path to image file', ->
+    original =
+      width: 512
+      height: 512
+    it 'should resize it to the specified dimension', (done) ->
+      expected =
+        width: 128
+        height: 256
+      out.on 'data', (data) ->
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.width
+          chai.expect(meta.height).to.be.equal expected.height
+          done()
+
+      width.send expected.width
+      height.send expected.height
+      ins.send  __dirname + '/fixtures/foo.jpeg'
+
+    it 'should resize it right when given just width', (done) ->
+      expected =
+        width: 128
+      out.on 'data', (data) ->
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.width
+          chai.expect(meta.height).to.be.equal expected.width
+          done()
 
       width.send expected.width
       ins.send __dirname + '/fixtures/lenna.png'
@@ -70,12 +155,11 @@ describe 'Resize component', ->
       expected =
         height: 128
       out.on 'data', (data) ->
-        chai.expect(data).to.be.an 'object'
-        chai.expect(data.width).to.be.equal expected.height
-        chai.expect(data.height).to.be.equal expected.height
-        chai.expect(data.originalWidth).to.be.equal original.width
-        chai.expect(data.originalHeight).to.be.equal original.height
-        done()
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.height
+          chai.expect(meta.height).to.be.equal expected.height
+          done()
 
       height.send expected.height
       ins.send __dirname + '/fixtures/lenna.png'
@@ -85,12 +169,11 @@ describe 'Resize component', ->
         width: 256
         height: 256
       out.on 'data', (data) ->
-        chai.expect(data).to.be.an 'object'
-        chai.expect(data.width).to.be.equal expected.width
-        chai.expect(data.height).to.be.equal expected.height
-        chai.expect(data.originalWidth).to.be.equal original.width
-        chai.expect(data.originalHeight).to.be.equal original.height
-        done()
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.width
+          chai.expect(meta.height).to.be.equal expected.height
+          done()
 
       ins.send __dirname + '/fixtures/lenna.png'
 
@@ -99,29 +182,69 @@ describe 'Resize component', ->
         width: 512
         height: 512
       out.on 'data', (data) ->
-        chai.expect(data).to.be.an 'object'
-        chai.expect(data.width).to.be.equal expected.width
-        chai.expect(data.height).to.be.equal expected.height
-        chai.expect(data.originalWidth).to.be.equal original.width
-        chai.expect(data.originalHeight).to.be.equal original.height
-        chai.expect(data.width).to.be.equal data.originalWidth
-        chai.expect(data.height).to.be.equal data.originalHeight
-        done()
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.width
+          chai.expect(meta.height).to.be.equal expected.height
+          done()
 
       width.send 1024
       ins.send __dirname + '/fixtures/lenna.png'
 
-  describe 'when passed a GIF', ->
+  describe 'when passed a missing image file', ->
+    it 'should error', (done) ->
+      error.on 'data', (data) ->
+        err = Error 'Input file is of an unsupported image format'
+        chai.expect(data).to.be.eql err
+        done()
+      ins.send  __dirname + '/fixtures/do-not-exist.jpeg'
+
+  describe 'when passed an invalid image file', ->
+    it 'should error', (done) ->
+      error.on 'data', (data) ->
+        err = Error 'Input file is of an unsupported image format'
+        chai.expect(data).to.be.eql err
+        done()
+      ins.send  __dirname + '/Resize.coffee'
+
+  describe 'when passed an invalid buffer', ->
+    it 'should error', (done) ->
+      error.on 'data', (data) ->
+        err = Error 'Input file is of an unsupported image format'
+        chai.expect(data).to.be.eql err
+        done()
+      testutils.getBuffer __dirname + '/Resize.coffee', (buffer) ->
+        ins.send buffer
+
+  describe 'when passed a GIF buffer', ->
     original =
       width: 500
     it 'should resize it to the specified dimension', (done) ->
+      @timeout 5000
       expected =
         width: 256
       out.on 'data', (data) ->
-        chai.expect(data).to.be.an 'object'
-        chai.expect(data.width).to.be.equal expected.width
-        chai.expect(data.originalWidth).to.be.equal original.width
-        done()
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.width
+          done()
+
+      width.send expected.width
+      testutils.getBuffer __dirname + '/fixtures/foo.gif', (buffer) ->
+        ins.send buffer
+
+  describe 'when passed a path to GIF file', ->
+    original =
+      width: 500
+    it 'should resize it to the specified dimension', (done) ->
+      @timeout 5000
+      expected =
+        width: 256
+      out.on 'data', (data) ->
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.width
+          done()
 
       width.send expected.width
       ins.send __dirname + '/fixtures/foo.gif'
@@ -134,10 +257,27 @@ describe 'Resize component', ->
       expected =
         width: 1024
       out.on 'data', (data) ->
-        chai.expect(data).to.be.an 'object'
-        chai.expect(data.width).to.be.equal expected.width
-        chai.expect(data.originalWidth).to.be.equal original.width
-        done()
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.width
+          done()
+
+      width.send expected.width
+      testutils.getBuffer __dirname + '/fixtures/foo.jpeg', (buffer) ->
+        ins.send buffer
+
+  describe 'when passed a path to JPG file', ->
+    original =
+      width: 2048
+      height: 1536
+    it 'should resize it to the specified dimension', (done) ->
+      expected =
+        width: 1024
+      out.on 'data', (data) ->
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.width
+          done()
 
       width.send expected.width
       ins.send __dirname + '/fixtures/foo.jpeg'
@@ -151,10 +291,28 @@ describe 'Resize component', ->
       expected =
         width: 256
       out.on 'data', (data) ->
-        chai.expect(data).to.be.an 'object'
-        chai.expect(data.width).to.be.equal expected.width
-        chai.expect(data.originalWidth).to.be.equal original.width
-        done()
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.width
+          done()
+
+      width.send expected.width
+      testutils.getBuffer __dirname + '/fixtures/foo.webp', (buffer) ->
+        ins.send buffer
+
+  describe.skip 'when passed a path to WEBP file', ->
+    original =
+      width: 550
+      height: 404
+    it 'should resize it to the specified dimension', (done) ->
+      @timeout 10000
+      expected =
+        width: 256
+      out.on 'data', (data) ->
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.width
+          done()
 
       width.send expected.width
       ins.send __dirname + '/fixtures/foo.webp'
@@ -167,10 +325,27 @@ describe 'Resize component', ->
       expected =
         width: 256
       out.on 'data', (data) ->
-        chai.expect(data).to.be.an 'object'
-        chai.expect(data.width).to.be.equal expected.width
-        chai.expect(data.originalWidth).to.be.equal original.width
-        done()
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.width
+          done()
+
+      width.send expected.width
+      testutils.getBuffer __dirname + '/fixtures/foo.tif', (buffer) ->
+        ins.send buffer
+
+  describe 'when passed a path to TIFF file', ->
+    original =
+      width: 1076
+      height: 750
+    it 'should resize it to the specified dimension', (done) ->
+      expected =
+        width: 256
+      out.on 'data', (data) ->
+        buffer = sharp data
+        buffer.metadata (err, meta) ->
+          chai.expect(meta.width).to.be.equal expected.width
+          done()
 
       width.send expected.width
       ins.send __dirname + '/fixtures/foo.tif'


### PR DESCRIPTION
Merges functionality of both `Resize` and `ResizeBuffer`: now `Resize` accepts buffers _or_ file paths. It also has extra useful outports: `original`, `resized` dimensions and `metadata`.
